### PR TITLE
Add output directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@
 
 # Misc
 .settings/language.settings.xml
+SAM3X/
+SAM3X_RTOS/
+SAM4E_RTOS/
+SAM4S_RTOS/
+SAME51_RTOS/
+SAME70_RTOS/


### PR DESCRIPTION
Added the following directories to .gitignore:
SAM3X/
SAM3X_RTOS/
SAM4E_RTOS/
SAM4S_RTOS/
SAME51_RTOS/
SAME70_RTOS/

Maybe it now makes sense to use an "output" directory to group the different architecture builds and at that one directory to .gitignore.